### PR TITLE
Larger on-screen touch controls in bottom

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -5,12 +5,9 @@
   padding: 0;
 }
 
-html {
-  font-size: 14px;
-}
-
 html,
 body {
+  font-size: 16px;
   height: 100%;
 }
 
@@ -21,7 +18,7 @@ body {
 .game {
   display: grid;
   grid-template-columns: 50% 50%;
-  grid-template-rows: auto auto auto 120px;
+  grid-template-rows: 94px 36px calc(100vh - 270px) 140px;
 }
 
 .setup {
@@ -137,6 +134,11 @@ label[for="configuration-toggle"] {
   color: #fff;
   background-color: #333;
   font-family: "Major Mono Display", monospace;
+}
+
+.level::before,
+.score::before {
+  font-size: 0.9rem;
 }
 
 .level::before {
@@ -428,13 +430,11 @@ label[for="configuration-toggle"] {
   border: none;
 }
 
-@media (min-width: 375px) {
-  html {
-    font-size: 16px;
-  }
-}
-
 @media (min-width: 768px) {
+  .game {
+    grid-template-rows: 58px 36px calc(100vh - 234px) 140px;
+  }
+
   .setup input[id="columns"],
   .setup input[id="rows"] {
     margin-bottom: 0;

--- a/src/styles.css
+++ b/src/styles.css
@@ -343,10 +343,12 @@ label[for="configuration-toggle"] {
 
 .game-controls {
   display: none;
-  grid-column-start: span 2;
-  justify-self: center;
   grid-template-columns: repeat(3, 40px);
   grid-template-rows: repeat(3, 40px);
+  position: absolute;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
 }
 
 .game-controls .cross {

--- a/src/styles.css
+++ b/src/styles.css
@@ -21,7 +21,7 @@ body {
 .game {
   display: grid;
   grid-template-columns: 50% 50%;
-  grid-template-rows: auto auto auto 90px;
+  grid-template-rows: auto auto auto 120px;
 }
 
 .setup {
@@ -343,8 +343,8 @@ label[for="configuration-toggle"] {
   display: none;
   grid-column-start: span 2;
   justify-self: center;
-  grid-template-columns: repeat(3, 30px);
-  grid-template-rows: repeat(3, 30px);
+  grid-template-columns: repeat(3, 40px);
+  grid-template-rows: repeat(3, 40px);
 }
 
 .game-controls .cross {

--- a/src/styles.css
+++ b/src/styles.css
@@ -19,6 +19,7 @@ body {
   display: grid;
   grid-template-columns: 50% 50%;
   grid-template-rows: 94px 36px calc(100vh - 270px) 140px;
+  align-items: start;
 }
 
 .setup {
@@ -156,7 +157,6 @@ label[for="configuration-toggle"] {
   padding: 10px;
   margin: 10px;
   justify-content: center;
-  align-content: center;
   position: relative;
   transition: transform 0.5s ease-out;
   pointer-events: none;


### PR DESCRIPTION
To handle https://github.com/jouni-kantola/grid-snake/issues/9, on-screen controls now larger and pushed to bottom of page.